### PR TITLE
Remove unused namespaces

### DIFF
--- a/02-FPTurtle.fsx
+++ b/02-FPTurtle.fsx
@@ -17,7 +17,6 @@ The client must keep track of the current state and pass it into the next functi
 
 #load "Common.fsx"
 
-open System
 open Common
 
 // ======================================

--- a/03-Api_OO_Core.fsx
+++ b/03-Api_OO_Core.fsx
@@ -19,7 +19,6 @@ input and returns a Result containing any errors.
 #load "Common.fsx"
 #load "OOTurtleLib.fsx"
 
-open System
 open Common
 
 // ======================================

--- a/04-Api_FP_Core.fsx
+++ b/04-Api_FP_Core.fsx
@@ -21,7 +21,6 @@ The API layer manages the state (rather than the client) by storing a mutable tu
 #load "FPTurtleLib.fsx"
 #load "TurtleApiHelpers.fsx"
 
-open System
 open Common
 open FPTurtleLib
 open TurtleApiHelpers // helpers for API validation, etc

--- a/05-TurtleAgent.fsx
+++ b/05-TurtleAgent.fsx
@@ -23,7 +23,6 @@ storing the current state as a parameter in the recursive message processing loo
 #load "FPTurtleLib.fsx"
 #load "TurtleApiHelpers.fsx"
 
-open System
 open Common
 open TurtleApiHelpers // helpers for API validation, etc
 
@@ -33,7 +32,6 @@ open TurtleApiHelpers // helpers for API validation, etc
 
 module AgentImplementation = 
 
-    open Result
     open FPTurtleLib
 
     type TurtleCommand = 

--- a/06-DependencyInjection_Interface-1.fsx
+++ b/06-DependencyInjection_Interface-1.fsx
@@ -17,7 +17,6 @@ The client injects a specific turtle implementation via the API's constructor.
 #load "Common.fsx"
 #load "OOTurtleLib.fsx"
 
-open System
 open Common
 
 // ============================================================================

--- a/06-DependencyInjection_Interface-2.fsx
+++ b/06-DependencyInjection_Interface-2.fsx
@@ -17,11 +17,8 @@ The client injects a specific turtle implementation via the API's constructor.
 #load "Common.fsx"
 #load "OOTurtleLib.fsx"
 #load "FPTurtleLib.fsx"
-#load "TurtleApiHelpers.fsx"
 
-open System
 open Common
-open TurtleApiHelpers // helpers for API validation, etc
 
 
 // ============================================================================

--- a/07-DependencyInjection_Functions-1.fsx
+++ b/07-DependencyInjection_Functions-1.fsx
@@ -21,7 +21,6 @@ No interface is passed to the constructor.
 #load "FPTurtleLib.fsx"
 #load "TurtleApiHelpers.fsx"
 
-open System
 open Common
 open FPTurtleLib
 open TurtleApiHelpers // helpers for API validation, etc
@@ -83,7 +82,6 @@ module TurtleApi_PassInAllFunctions =
 
 module TurtleImplementation_PassInAllFunctions = 
     
-    open FPTurtleLib
     open TurtleApi_PassInAllFunctions
 
     let log = printfn "%s"

--- a/07-DependencyInjection_Functions-2.fsx
+++ b/07-DependencyInjection_Functions-2.fsx
@@ -21,7 +21,6 @@ No interface is passed to the constructor.
 #load "FPTurtleLib.fsx"
 #load "TurtleApiHelpers.fsx"
 
-open System
 open Common
 open FPTurtleLib
 open TurtleApiHelpers // helpers for API validation, etc
@@ -96,7 +95,6 @@ module TurtleApi_PassInSingleFunction =
 
 module TurtleImplementation_PassInSingleFunction = 
     
-    open FPTurtleLib
     open TurtleApi_PassInSingleFunction
 
     let log = printfn "%s"

--- a/08-StateMonad.fsx
+++ b/08-StateMonad.fsx
@@ -20,7 +20,6 @@ As a result, there are no mutables anywhere.
 #load "Common.fsx"
 #load "FPTurtleLib.fsx"
 
-open System
 open Common
 open FPTurtleLib
 

--- a/09-BatchCommands.fsx
+++ b/09-BatchCommands.fsx
@@ -18,7 +18,6 @@ This approach means that there is no state that needs to be persisted between ca
 #load "Common.fsx"
 #load "FPTurtleLib.fsx"
 
-open System
 open Common
 
 // ======================================
@@ -27,7 +26,6 @@ open Common
 
 module TurtleCommmandHandler = 
 
-    open Result
     open FPTurtleLib
 
     /// Function to log a message

--- a/10-EventSourcing.fsx
+++ b/10-EventSourcing.fsx
@@ -21,7 +21,6 @@ Neither the client nor the command handler needs to track state.  Only the Event
 #load "Common.fsx"
 #load "FPTurtleLib.fsx"
 
-open System
 open Common
 open FPTurtleLib
 

--- a/12-BranchingOnResponse.fsx
+++ b/12-BranchingOnResponse.fsx
@@ -18,7 +18,6 @@ while the state is being passed around behind the scenes.
 #load "Common.fsx"
 #load "FPTurtleLib2.fsx"
 
-open System
 open Common
 open FPTurtleLib2
 
@@ -78,8 +77,7 @@ module TurtleStateComputation =
 
 module TurtleComputationClient = 
 
-    open TurtleStateComputation 
-    open Result
+    open TurtleStateComputation
 
     /// Function to log a message
     let log message =

--- a/13-Interpreter-v1.fsx
+++ b/13-Interpreter-v1.fsx
@@ -14,12 +14,9 @@ This Turtle Program can then interpreted later in various ways
 ====================================== *)
 
 
-open System
-
 #load "Common.fsx"
 #load "FPTurtleLib2.fsx"
 
-open System
 open Common
 open FPTurtleLib2
 

--- a/13-Interpreter-v2.fsx
+++ b/13-Interpreter-v2.fsx
@@ -14,12 +14,9 @@ This Turtle Program can then interpreted later in various ways
 ====================================== *)
 
 
-open System
-
 #load "Common.fsx"
 #load "FPTurtleLib2.fsx"
 
-open System
 open Common
 open FPTurtleLib2
 


### PR DESCRIPTION
There is a bunch of `open` statements not really needed, mainly `open System`.