### PR TITLE
Use built-in Result type

### DIFF
--- a/04-Api_FP_Core.fsx
+++ b/04-Api_FP_Core.fsx
@@ -86,11 +86,11 @@ module TurtleApiLayer =
                     lift2R setColor colorR stateR
 
                 | _ -> 
-                    Failure (InvalidCommand commandStr)
+                    Error (InvalidCommand commandStr)
         
             // Lift `updateState` into the world of Results and 
             // call it with the new state.
-            mapR updateState newStateR
+            Result.map updateState newStateR
 
             // Return the final result (output of updateState)
 
@@ -176,6 +176,6 @@ TurtleApiClient.drawPolygon 4
 
 // test errors
 TurtleApiClient.triggerError()  
-// Failure (InvalidDistance "bad")
+// Error (InvalidDistance "bad")
 *)
 

--- a/05-TurtleAgent.fsx
+++ b/05-TurtleAgent.fsx
@@ -134,7 +134,7 @@ module TurtleApiLayer =
                     }
 
                 | _ -> 
-                    Failure (InvalidCommand commandStr)
+                    Error (InvalidCommand commandStr)
         
             // return any errors
             result
@@ -219,7 +219,7 @@ TurtleApiClient.drawPolygon 4
 
 // test errors
 AgentClient.triggerError()  
-// Failure (InvalidDistance "bad")
+// Error (InvalidDistance "bad")
 *)
 
 

--- a/06-DependencyInjection_Interface-2.fsx
+++ b/06-DependencyInjection_Interface-2.fsx
@@ -69,27 +69,27 @@ module TurtleApiLayer_FP =
     // convert the distance parameter to a float, or throw an exception
     let validateDistance distanceStr =
         try
-            Success (float distanceStr)
+            Ok (float distanceStr)
         with
         | ex -> 
-            Failure (InvalidDistance distanceStr)
+            Error (InvalidDistance distanceStr)
 
     // convert the angle parameter to a float, or throw an exception
     let validateAngle angleStr =
         try
-            Success ((float angleStr) * 1.0<Degrees>)
+            Ok ((float angleStr) * 1.0<Degrees>)
         with
         | ex -> 
-            Failure (InvalidAngle angleStr)
+            Error (InvalidAngle angleStr)
 
     // convert the color parameter to a PenColor, or throw an exception
     let validateColor colorStr =
         match colorStr with
-        | "Black" -> Success Black
-        | "Blue" -> Success Blue
-        | "Red" -> Success Red
+        | "Black" -> Ok Black
+        | "Blue" -> Ok Blue
+        | "Red" -> Ok Red
         | _ -> 
-            Failure (InvalidColor colorStr)
+            Error (InvalidColor colorStr)
 
     type TurtleApi(turtleFunctions: TurtleFunctions) =
 
@@ -104,7 +104,7 @@ module TurtleApiLayer_FP =
         member this.Exec (commandStr:string) = 
             let tokens = commandStr.Split(' ') |> List.ofArray |> List.map trimString
 
-            // return Success of unit, or Failure
+            // return Ok of unit, or Error
             match tokens with
             | [ "Move"; distanceStr ] -> result {
                 let! distance = validateDistance distanceStr 
@@ -130,7 +130,7 @@ module TurtleApiLayer_FP =
                 updateState newState
                 }
             | _ -> 
-                Failure (InvalidCommand commandStr)
+                Error (InvalidCommand commandStr)
         
 
 // ----------------------------

--- a/07-DependencyInjection_Functions-1.fsx
+++ b/07-DependencyInjection_Functions-1.fsx
@@ -49,7 +49,7 @@ module TurtleApi_PassInAllFunctions =
         member this.Exec move turn penUp penDown setColor (commandStr:string) = 
             let tokens = commandStr.Split(' ') |> List.ofArray |> List.map trimString
 
-            // return Success of unit, or Failure
+            // return Ok of unit, or Error
             match tokens with
             | [ "Move"; distanceStr ] -> result {
                 let! distance = validateDistance distanceStr 
@@ -75,7 +75,7 @@ module TurtleApi_PassInAllFunctions =
                 updateState newState
                 }
             | _ -> 
-                Failure (InvalidCommand commandStr)
+                Error (InvalidCommand commandStr)
 
 // -----------------------------
 // Turtle Implementations for "Pass in all functions" design
@@ -145,6 +145,6 @@ do
 do
     let mockApi s = 
         printfn "[MockAPI] %s" s
-        Success ()
+        Ok ()
     TurtleApiClient_PassInAllFunctions.drawTriangle(mockApi) 
 

--- a/07-DependencyInjection_Functions-2.fsx
+++ b/07-DependencyInjection_Functions-2.fsx
@@ -55,7 +55,7 @@ module TurtleApi_PassInSingleFunction =
         member this.Exec turtleFn (commandStr:string) = 
             let tokens = commandStr.Split(' ') |> List.ofArray |> List.map trimString
 
-            // return Success of unit, or Failure
+            // return Ok of unit, or Error
             match tokens with
             | [ "Move"; distanceStr ] -> result {
                 let! distance = validateDistance distanceStr 
@@ -86,7 +86,7 @@ module TurtleApi_PassInSingleFunction =
                 updateState newState
                 }
             | _ -> 
-                Failure (InvalidCommand commandStr)
+                Error (InvalidCommand commandStr)
 
       
 

--- a/Common.fsx
+++ b/Common.fsx
@@ -64,32 +64,20 @@ let dummyDrawLine log oldPos newPos color =
 let trimString (str:string) = str.Trim()
 
 // ======================================
-// Result type and companion module
+// Result companion module
 // ======================================
-
-type Result<'a,'error> = 
-    | Success of 'a
-    | Failure of 'error
 
 module Result = 
 
     let returnR x = 
-        Success x
-
-    let bindR f xR = 
-        match xR with
-        | Success x -> f x
-        | Failure err -> Failure err 
+        Ok x
 
     // infix version of bind
     let ( >>= ) xR f = 
-        bindR f xR
-
-    let mapR f = 
-        bindR (f >> returnR)
+        Result.bind f xR
 
     // infix version of map
-    let ( <!> ) = mapR 
+    let ( <!> ) = Result.map
 
     let applyR fR xR = 
         fR >>= (fun f ->
@@ -108,7 +96,7 @@ module Result =
     /// Computation Expression
     type ResultBuilder() =
         member this.Bind(m:Result<'a,'error>,f:'a -> Result<'b,'error>) = 
-            bindR f m
+            Result.bind f m
         member this.Return(x) :Result<'a,'error> = 
             returnR x
         member this.ReturnFrom(m) :Result<'a,'error> = 

--- a/TurtleApiHelpers.fsx
+++ b/TurtleApiHelpers.fsx
@@ -33,24 +33,24 @@ type ErrorMessage =
 // convert the distance parameter to a float, or throw an exception
 let validateDistance distanceStr =
     try
-        Success (float distanceStr)
+        Ok (float distanceStr)
     with
     | ex -> 
-        Failure (InvalidDistance distanceStr)
+        Error (InvalidDistance distanceStr)
 
 // convert the angle parameter to a float, or throw an exception
 let validateAngle angleStr =
     try
-        Success ((float angleStr) * 1.0<Degrees>)
+        Ok ((float angleStr) * 1.0<Degrees>)
     with
     | ex -> 
-        Failure (InvalidAngle angleStr)
+        Error (InvalidAngle angleStr)
 
 // convert the color parameter to a PenColor, or throw an exception
 let validateColor colorStr =
     match colorStr with
-    | "Black" -> Success Black
-    | "Blue" -> Success Blue
-    | "Red" -> Success Red
+    | "Black" -> Ok Black
+    | "Blue" -> Ok Blue
+    | "Red" -> Ok Red
     | _ -> 
-        Failure (InvalidColor colorStr)
+        Error (InvalidColor colorStr)


### PR DESCRIPTION
`Result` has been around quite some time, so I think for newbies that already started with Result it would be less confusing.